### PR TITLE
LEA-20 Update Backend to Use Elasticache

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,16 +3,26 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 )
 
 var (
-	RedisHost string
+	RedisHost  string
+	TLSEnabled bool
 )
 
 func InitConfig() {
 	env := os.Getenv("ENVIRONMENT")
+	tlsEnv := os.Getenv("TLS_ENABLED")
+	tlsEnabled, err := strconv.ParseBool(tlsEnv)
+	if err != nil {
+		tlsEnabled = false
+	}
+	TLSEnabled = tlsEnabled
+
 	if env == "local" {
 		RedisHost = "localhost:6379"
+		TLSEnabled = false
 		fmt.Println("Running in local mode")
 	} else {
 		redisEnvHost := os.Getenv("REDIS_HOST")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,7 +15,12 @@ func InitConfig() {
 		RedisHost = "localhost:6379"
 		fmt.Println("Running in local mode")
 	} else {
-		RedisHost = "redis:6379"
+		redisEnvHost := os.Getenv("REDIS_HOST")
+		if redisEnvHost != "" {
+			RedisHost = redisEnvHost
+		} else {
+			RedisHost = "redis:6379"
+		}
 		fmt.Println("Running in Docker mode")
 	}
 }

--- a/pkg/services/redis_service.go
+++ b/pkg/services/redis_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"Learning-Mode-AI-Snapshot-Service/pkg/config"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"log"

--- a/pkg/services/redis_service.go
+++ b/pkg/services/redis_service.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+
 	"github.com/go-redis/redis/v8"
 )
 
@@ -16,13 +17,18 @@ var (
 )
 
 func InitRedis() {
+	var tlsConfig *tls.Config
+	if config.TLSEnabled {
+		tlsConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	} else {
+		tlsConfig = nil
+	}
+
 	RedisClient = redis.NewClient(&redis.Options{
-		Addr:     config.RedisHost, // Redis address
-		TLSConfig: &tls.Config{
-			// Depending on your certificate setup,
-			// you might need to customize this further.
-			InsecureSkipVerify: true, // Use caution: this bypasses certificate verification.
-		},
+		Addr:      config.RedisHost, // Redis address
+		TLSConfig: tlsConfig,
 	})
 
 	err := RedisClient.Ping(Ctx).Err()

--- a/pkg/services/redis_service.go
+++ b/pkg/services/redis_service.go
@@ -17,16 +17,17 @@ var (
 func InitRedis() {
 	RedisClient = redis.NewClient(&redis.Options{
 		Addr:     config.RedisHost, // Redis address
-		Password: "",               // No password set
-		DB:       0,                // Use default DB
+		TLSConfig: &tls.Config{
+			// Depending on your certificate setup,
+			// you might need to customize this further.
+			InsecureSkipVerify: true, // Use caution: this bypasses certificate verification.
+		},
 	})
 
-	// Test the connection
-	_, err := RedisClient.Ping(Ctx).Result()
+	err := RedisClient.Ping(ctx).Err()
 	if err != nil {
-		log.Fatalf("Failed to connect to Redis: %v", err)
+		panic(err)
 	}
-	log.Println("Connected to Redis")
 }
 
 // StoreSnapshotInRedis saves the snapshot data to Redis under the video ID key

--- a/pkg/services/redis_service.go
+++ b/pkg/services/redis_service.go
@@ -24,7 +24,7 @@ func InitRedis() {
 		},
 	})
 
-	err := RedisClient.Ping(ctx).Err()
+	err := RedisClient.Ping(Ctx).Err()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
All Redis-based services (main-backend, ai-service, snapshot-service) now use ElastiCache if redis_host is defined
config.go:
Updated RedisHost to dynamically fetch from the environment (REDIS_HOST).
Falls back to redis:6379 if not set.

redis_service.go:
Added TLS configuration to securely connect to ElastiCache.
Enabled InsecureSkipVerify: true to bypass cert validation (temporary).